### PR TITLE
remove endless loop in Offline.off()

### DIFF
--- a/coffee/offline.coffee
+++ b/coffee/offline.coffee
@@ -98,7 +98,8 @@ Offline.off = (event, handler) ->
     while i < handlers[event].length
       [ctx, _handler] = handlers[event][i]
       if _handler is handler
-        handlers[event].splice i--, 1
+        handlers[event].splice i, 1
+      ++i
 
 Offline.trigger = (event) ->
   if handlers[event]?


### PR DESCRIPTION
If you call Offline.off() with a specific handler you get an endless loop.

First of all the loop checks `i < handlers[event].length` but in the loop `i` is decremented.

Second, the compiled JavaScript looks like this:

```
while (i < handlers[event].length) {
    _ref = handlers[event][i], ctx = _ref[0], _handler = _ref[1];
    if (_handler === handler) {
        _results.push(handlers[event].splice(i--, 1));
    } else {
        _results.push(void 0);
    }
}
```

In the else branch `i` isn't even touched.

I haven't used CoffeeScript so please check if i placed the `i++` right.
