### PR TITLE
fix reconnect button not showing in Chrome 30+

### DIFF
--- a/coffee/reconnect.coffee
+++ b/coffee/reconnect.coffee
@@ -50,13 +50,11 @@ nope = ->
 
 rc.tryNow = tryNow
 
-setTimeout ->
-  unless Offline.getOption('reconnect') is false
-    reset()
+unless Offline.getOption('reconnect') is false
+  reset()
 
-    Offline.on 'down', down
-    Offline.on 'confirmed-down', nope
-    Offline.on 'up', up
+  Offline.on 'down', down
+  Offline.on 'confirmed-down', nope
+  Offline.on 'up', up
 
-    Offline.reconnect = rc
-, 0
+  Offline.reconnect = rc

--- a/js/reconnect.js
+++ b/js/reconnect.js
@@ -65,14 +65,12 @@
 
   rc.tryNow = tryNow;
 
-  setTimeout(function() {
-    if (Offline.getOption('reconnect') !== false) {
-      reset();
-      Offline.on('down', down);
-      Offline.on('confirmed-down', nope);
-      Offline.on('up', up);
-      return Offline.reconnect = rc;
-    }
-  }, 0);
+  if (Offline.getOption('reconnect') !== false) {
+    reset();
+    Offline.on('down', down);
+    Offline.on('confirmed-down', nope);
+    Offline.on('up', up);
+    return Offline.reconnect = rc;
+  }
 
 }).call(this);


### PR DESCRIPTION
The reconnect button doesn't show on chrome because <code>Offline.reconnect</code> isn't initialize until <code>init</code> function is complete. It works fine if we remove the <code>setTimeout</code> function in reconnect.js.  
