### PR TITLE
Try to sniff correct protocol for connection image

### DIFF
--- a/js/offline.js
+++ b/js/offline.js
@@ -34,7 +34,7 @@
       },
       image: {
         url: function() {
-          return "http://dqakt69vkj09v.cloudfront.net/are-we-online.gif?_=" + (Math.floor(Math.random() * 1000000000));
+          return ("https:" === document.location.protocol ? "https:" : "http:") + "//dqakt69vkj09v.cloudfront.net/are-we-online.gif?_=" + (Math.floor(Math.random() * 1000000000));
         }
       },
       active: 'image'


### PR DESCRIPTION
This attempts to load the connection testing image using https if appropriate.
Currently there is an option to set any image url, but it would be nice to default to following the same protocol as the page.  I used "document.location.protocol" instead of "//" for compatibility, but maybe its not necessary?
This might _potentially_ solve [issue #20](https://github.com/HubSpot/offline/issues/20), as well.

Let me know if there are any problems with this PR, and thanks for the great lib.
-Joe
