### PR TITLE
Updated ignore in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,14 @@
   ],
   "license": "MIT",
   "ignore": [
+    "**/.*",
     "node_modules",
-    "bower_components"
+    "bower_components",
+    "coffee",
+    "docs",
+    "js",
+    "test",
+    "bower.json",
+    "package.json"
   ]
 }


### PR DESCRIPTION
So that only distribution files get distributed using Bower install, rather then the whole Git folder.
More information: https://github.com/bower/bower.json-spec
