### PR TITLE
Update version link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Improve the experience of your app when your users lose connection.
 Installing
 ----------
 
-Include [the javascript](https://raw.github.com/HubSpot/offline/v0.4.7/offline.min.js) and one of [the themes](http://github.hubspot.com/offline/docs/welcome/) on your site.  You're done!
+Include [the javascript](https://github.com/HubSpot/offline/blob/v0.6.0/offline.min.js) and one of [the themes](http://github.hubspot.com/offline/docs/welcome/) on your site.  You're done!
 
 Advanced
 --------


### PR DESCRIPTION
Or should we point to master?

Also, on https://github.com/HubSpot/offline/releases the 0.4.7 is stated as the 'Latest release'. This makes is very confusing which version to download..
