### PR TITLE
Sets z-index for .offline-ui to the maximum allowed value

### DIFF
--- a/sass/_offline-theme-base-indicator.sass
+++ b/sass/_offline-theme-base-indicator.sass
@@ -7,7 +7,7 @@
     display: none
     position: fixed
     background: #fff
-    z-index: 2147483647
+    z-index: 2000
     display: inline-block
 
     .offline-ui-retry

--- a/sass/_offline-theme-base.sass
+++ b/sass/_offline-theme-base.sass
@@ -8,7 +8,7 @@
     display: none
     position: fixed
     background: #fff
-    z-index: 2147483647
+    z-index: 2000
     margin: auto
     top: 0
     left: 0


### PR DESCRIPTION
When working with Bootstrap 3.1.1 I noticed that if you use a fixed navbar the Offline UI elements are obscured by Bootstrap elements. After a bit of frustration I realized that the z-index in Bootstrap was simply higher than that in Offline. Here I have a set the [z-index to the maximum allowed value](http://softwareas.com/whats-the-maximum-z-index) in order to ensure the UI elements always remain above any other elements rendered to the page.
