### PR TITLE
Fix #99 (Consider 502 code as down state)

### DIFF
--- a/coffee/offline.coffee
+++ b/coffee/offline.coffee
@@ -118,7 +118,9 @@ Offline.trigger = (event) ->
 
 checkXHR = (xhr, onUp, onDown) ->
   checkStatus = ->
-    if xhr.status and xhr.status < 12000
+    if xhr.status and xhr.status == 502
+      onDown()
+    else if xhr.status and xhr.status < 12000
       onUp()
     else
       onDown()


### PR DESCRIPTION
This fix only considers a 502 state as down as opposed to any 5xx state.  This is because other 5xx codes could mean a successful communication with the server (similar to 404 when using the image checking method)