### PR TITLE
Add 'main' attribute enabling webpack support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "Zack Bloom <zackbloom@gmail.com>"
   ],
   "license": "MIT",
+  "main": "offline.min.js",
   "devDependencies": {
     "grunt-contrib-coffee": "~0.7.0",
     "coffee-script": "~1.6.3",


### PR DESCRIPTION
Bundlers like Webpack use the 'main' attribute in the package.json to find the correct source file.