### PR TITLE
Fixing to initial copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014 HubSpot, Inc.
+Copyright (c) 2013 HubSpot, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
I am not a lawyer but according to http://www.copyright.gov/circs/circ01.pdf (See screenshot of relevant section below), mentioning the first year of publication in the copyright is a good thing

![selection_008](https://cloud.githubusercontent.com/assets/829526/12409934/7021c3a6-be95-11e5-8d1a-18f6948571e0.png)

The commit 6bd0b8b51043c189071 changed the copyright year from 2013 to 2014

This commit reverts back that change, so that license year is again 2013 (As it was, when added first time in commit 74a1c54539 )