### PR TITLE
0.7.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "offline-js",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "description": "Automatically detect when a browser is offline",
   "authors": [
     "Adam Schwartz <adam.flynn.schwartz@gmail.com>",


### PR DESCRIPTION
The version tagged [v0.7.14](https://github.com/HubSpot/offline/releases/tag/v0.7.14) doesn't match the commit published to npm, cf3f9fc00527bacf32ed87de9a3169d80c586815 which came later.

v0.7.13 was also published after v0.7.14, making this even more confusing.

I've published v0.7.15, which is the same as v0.7.14.

Fixes https://github.com/HubSpot/offline/issues/181