### PR TITLE
Prevent exception when localStorage is disabled on Chrome

### DIFF
--- a/coffee/simulate.coffee
+++ b/coffee/simulate.coffee
@@ -2,7 +2,12 @@ unless Offline
   throw new Error("Offline simulate brought in without offline.js")
 
 for state in ['up', 'down']
-  if document.querySelector("script[data-simulate='#{ state }']") or localStorage?.OFFLINE_SIMULATE is state
+    try
+      simulate = document.querySelector("script[data-simulate='#{ state }']") or localStorage?.OFFLINE_SIMULATE is state
+    catch e
+      simulate = false
+
+  if simulate
     Offline.options ?= {}
     Offline.options.checks ?= {}
     Offline.options.checks.active = state

--- a/js/simulate.js
+++ b/js/simulate.js
@@ -1,5 +1,5 @@
 (function() {
-  var base, i, len, ref, state;
+  var base, e, i, len, ref, simulate, state;
 
   if (!Offline) {
     throw new Error("Offline simulate brought in without offline.js");
@@ -8,15 +8,22 @@
   ref = ['up', 'down'];
   for (i = 0, len = ref.length; i < len; i++) {
     state = ref[i];
-    if (document.querySelector("script[data-simulate='" + state + "']") || (typeof localStorage !== "undefined" && localStorage !== null ? localStorage.OFFLINE_SIMULATE : void 0) === state) {
-      if (Offline.options == null) {
-        Offline.options = {};
-      }
-      if ((base = Offline.options).checks == null) {
-        base.checks = {};
-      }
-      Offline.options.checks.active = state;
+    try {
+      simulate = document.querySelector("script[data-simulate='" + state + "']") || (typeof localStorage !== "undefined" && localStorage !== null ? localStorage.OFFLINE_SIMULATE : void 0) === state;
+    } catch (_error) {
+      e = _error;
+      simulate = false;
     }
+  }
+
+  if (simulate) {
+    if (Offline.options == null) {
+      Offline.options = {};
+    }
+    if ((base = Offline.options).checks == null) {
+      base.checks = {};
+    }
+    Offline.options.checks.active = state;
   }
 
 }).call(this);


### PR DESCRIPTION
Prevent exception `Uncaught SecurityError: Failed to read the 'localStorage' property from 'Window': Access is denied for this document.`