### PR TITLE
fixes issue that occurs when a previously registered event handler calls .off/.on

### DIFF
--- a/coffee/offline.coffee
+++ b/coffee/offline.coffee
@@ -115,9 +115,8 @@ Offline.off = (event, handler) ->
 
 Offline.trigger = (event) ->
   if handlers[event]?
-    # temporary cache the handlers since its possible that the called functions will modify the handlers array by calling off/on 
-    eventHandlers = handlers[event][..]
-    for [ctx, handler] in eventHandlers
+    # we have to make a copy of the handlers since its possible that the called functions will modify the handlers array by calling off/on 
+    for [ctx, handler] in handlers[event][..]
       handler.call(ctx)
 
 checkXHR = (xhr, onUp, onDown) ->

--- a/coffee/offline.coffee
+++ b/coffee/offline.coffee
@@ -115,7 +115,9 @@ Offline.off = (event, handler) ->
 
 Offline.trigger = (event) ->
   if handlers[event]?
-    for [ctx, handler] in handlers[event]
+    # temporary cache the handlers since its possible that the called functions will modify the handlers array by calling off/on 
+    eventHandlers = handlers[event][..]
+    for [ctx, handler] in eventHandlers
       handler.call(ctx)
 
 checkXHR = (xhr, onUp, onDown) ->


### PR DESCRIPTION
I used offline.js with some event handlers that registered/unregistered events, thus possibly modifying handlers[event] while iterating through it. 

Example:

```javascript
Offline.on('up', () =>  {
   //do something...
   Offline.off('up',anotherHandler);
   //handlers['up'] is now one element shorter, but Offline.trigger continues to iterate with the original length
   //this will potentially skip one of the registered handlers and result in an outofindex error at the end of the loop
});
```

This patch fixes that problem by cloning the affected handlers before calling them.